### PR TITLE
23 corrigir despadronizações do projeto

### DIFF
--- a/CarlosECIA/src/main/java/com/projetofef/carlosecia/domains/enums/StatusFatura.java
+++ b/CarlosECIA/src/main/java/com/projetofef/carlosecia/domains/enums/StatusFatura.java
@@ -1,4 +1,4 @@
-package com.projetofef.carlosecia.enums;
+package com.projetofef.carlosecia.domains.enums;
 
 public enum StatusFatura {
     ABERTA(0, "ABERTA"), FECHADA(1, "FECHADA"), PAGA(2, "PAGA");

--- a/CarlosECIA/src/main/java/com/projetofef/carlosecia/domains/enums/StatusLancamento.java
+++ b/CarlosECIA/src/main/java/com/projetofef/carlosecia/domains/enums/StatusLancamento.java
@@ -2,6 +2,7 @@ package com.projetofef.carlosecia.domains.enums;
 
 public enum StatusLancamento {
     PENDENTE(0, "PENDENTE"), BAIXADO(1, "BAIXADO"), PARCIAL(2, "PARCIAL"), CANCELADO(3, "CANCELADO");
+
     private Integer id;
     private String descricao;
 

--- a/CarlosECIA/src/main/java/com/projetofef/carlosecia/domains/enums/TipoTransacao.java
+++ b/CarlosECIA/src/main/java/com/projetofef/carlosecia/domains/enums/TipoTransacao.java
@@ -1,12 +1,12 @@
 package com.projetofef.carlosecia.domains.enums;
 
-public enum tipoTransacao {
+public enum TipoTransacao {
     CREDITO(0,"CREDITO"), DEBITO(1, "DEBITO"), TRANSACAO(2, "TRANSACAO");
 
     private Integer id;
     private String descricao;
 
-    tipoTransacao(Integer id, String descricao) {
+    TipoTransacao(Integer id, String descricao) {
         this.id = id;
         this.descricao = descricao;
     }
@@ -27,14 +27,14 @@ public enum tipoTransacao {
         this.descricao = descricao;
     }
 
-    public static tipoTransacao toEnum(String descricao) {
+    public static TipoTransacao toEnum(String descricao) {
         if(descricao == null) return null;
-        for(tipoTransacao tipoTransacao : tipoTransacao.values()) {
+        for(TipoTransacao tipoTransacao : TipoTransacao.values()) {
             if(descricao.equals(tipoTransacao.getDescricao())){
                 return tipoTransacao;
             }
         }
-        throw new IllegalArgumentException("Transação Inválida!");
+        throw new IllegalArgumentException("TipoTransacao Inválida!");
     }
 }
 


### PR DESCRIPTION
Realizadas as padronizações necessárias:
- Classe StatusFatura movida para a pasta 'enums' de forma correta;
- A pasta 'enums' incorreta que estava fora da pasta domains foi excluída;
- O nome da classe 'TipoTransacao' que estava com a primeira letra minúscula também foi corrigida para seguir os padrões necessários.